### PR TITLE
[POCAM-57] move path-util out of dev and clean up script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "phpoffice/phpspreadsheet": "^1.11",
         "unocha/common_design": "^2.7.5",
         "webflo/drupal-finder": "^1.0.0",
+        "webmozart/path-util": "^2.3",
         "zaporylie/composer-drupal-optimizations": "^1.0"
     },
     "require-dev": {
@@ -55,7 +56,6 @@
         "drupal/upgrade_status": "^2.0",
         "drush/drush": "^9.0.0",
         "phpmd/phpmd": "^2.6",
-        "webmozart/path-util": "^2.3",
         "weitzman/drupal-test-traits": "^1.2",
         "weitzman/logintrait": "^1.1"
     },

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -1,11 +1,11 @@
 <?php
 
+namespace DrupalProject\composer;
+
 /**
  * @file
  * Contains \DrupalProject\composer\ScriptHandler.
  */
-
-namespace DrupalProject\composer;
 
 use Composer\Script\Event;
 use Composer\Semver\Comparator;
@@ -13,8 +13,14 @@ use DrupalFinder\DrupalFinder;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
+/**
+ * Class ScriptHandler.
+ */
 class ScriptHandler {
 
+  /**
+   * Set up Drupal expected files and directories.
+   */
   public static function createRequiredFiles(Event $event) {
     $fs = new Filesystem();
     $drupalFinder = new DrupalFinder();
@@ -27,15 +33,15 @@ class ScriptHandler {
       'themes',
     ];
 
-    // Required for unit testing
+    // Required for unit testing.
     foreach ($dirs as $dir) {
-      if (!$fs->exists($drupalRoot . '/'. $dir)) {
-        $fs->mkdir($drupalRoot . '/'. $dir);
-        $fs->touch($drupalRoot . '/'. $dir . '/.gitkeep');
+      if (!$fs->exists($drupalRoot . '/' . $dir)) {
+        $fs->mkdir($drupalRoot . '/' . $dir);
+        $fs->touch($drupalRoot . '/' . $dir . '/.gitkeep');
       }
     }
 
-    // Prepare the settings file for installation
+    // Prepare the settings file for installation.
     if (!$fs->exists($drupalRoot . '/sites/default/settings.php') and $fs->exists($drupalRoot . '/sites/default/default.settings.php')) {
       $fs->copy($drupalRoot . '/sites/default/default.settings.php', $drupalRoot . '/sites/default/settings.php');
       require_once $drupalRoot . '/core/includes/bootstrap.inc';
@@ -51,7 +57,7 @@ class ScriptHandler {
       $event->getIO()->write("Create a sites/default/settings.php file with chmod 0666");
     }
 
-    // Create the files directory with chmod 0777
+    // Create the files directory with chmod 0777.
     if (!$fs->exists($drupalRoot . '/sites/default/files')) {
       $oldmask = umask(0);
       $fs->mkdir($drupalRoot . '/sites/default/files', 0777);


### PR DESCRIPTION
Moving webmozart/path-util out of dev so it's not missing in the build:

```
Step 6/30 : RUN composer install --quiet --no-dev --prefer-dist &&     composer run gulp &&     mkdir -p html/sites/default &&     cp -a docker/settings.php docker/services.yml html/sites/default
 ---> Running in 657d11d3db2b

Fatal error: Uncaught Error: Class 'Webmozart\PathUtil\Path' not found in /srv/www/scripts/composer/ScriptHandler.php:45
```
(from https://github.com/UN-OCHA/pocam8-site/runs/764576277?check_suite_focus=true )

plus more phpcs-prompted changes.