### PR TITLE
[POCAM-57] rethink exposed form blocks

### DIFF
--- a/config/block.block.exposedformextractsheader.yml
+++ b/config/block.block.exposedformextractsheader.yml
@@ -1,4 +1,4 @@
-uuid: fcbf540d-6339-4e48-bea1-40478a85f894
+uuid: a2450328-cc01-4aa8-8b9d-4f3686d3f6a2
 langcode: en
 status: true
 dependencies:
@@ -8,14 +8,14 @@ dependencies:
     - views
   theme:
     - common_design_subtheme
-id: exposedformextractspage_1_3
+id: exposedformextractsheader
 theme: common_design_subtheme
 region: header_search
 weight: 0
 provider: null
-plugin: 'views_exposed_filter_block:extracts-page_1'
+plugin: 'views_exposed_filter_block:extracts-header'
 settings:
-  id: 'views_exposed_filter_block:extracts-page_1'
+  id: 'views_exposed_filter_block:extracts-header'
   label: ''
   provider: views
   label_display: visible

--- a/config/views.view.extracts.yml
+++ b/config/views.view.extracts.yml
@@ -392,6 +392,27 @@ display:
       tags:
         - 'config:field.storage.node.field_link'
         - 'config:search_api.index.extracts'
+  header:
+    display_plugin: page
+    id: header
+    display_title: header
+    position: 2
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      path: extracts-header
+      exposed_block: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+      tags:
+        - 'config:field.storage.node.field_link'
+        - 'config:search_api.index.extracts'
   page_1:
     display_plugin: page
     id: page_1

--- a/html/modules/custom/pocam_general/pocam_general.module
+++ b/html/modules/custom/pocam_general/pocam_general.module
@@ -87,7 +87,12 @@ function pocam_general_tokens($type, $tokens, array $data = [], array $options =
  */
 function pocam_general_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if ($form['#id'] == 'views-exposed-form-extracts-page-1') {
-    $form['search']['#placeholder'] = t('Search for phrases or keywords');
+    if (\Drupal::service('path.matcher')->isFrontPage()) {
+      $form['search']['#placeholder'] = t('Search for phrases or keywords');
+    }
+    else {
+      $form['search']['#placeholder'] = t('Search');
+    }
   }
 }
 

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -14,30 +14,11 @@ function common_design_subtheme_form_alter(&$form, FormStateInterface $form_stat
   // To use this for Views exposed forms, copy the form alter hook into your
   // subtheme and add the relevant Views IDs to this array in your subtheme.
   $includeView = [
-    'views-exposed-form-extracts-page-1',
+    'views-exposed-form-extracts-header',
   ];
 
   // If in array above, add search--inline attributes.
   if (in_array($form['#id'], $includeView)) {
-    // TODO: find a better way.
-    // We have inline-search forms in the headers and on a couple of pages.
-    // We only want to target the form in the header, but it's not clear which
-    // that is. Trial and error shows they're processed in the same order each
-    // time, but this is flimsy.
-    if (\Drupal::service('path.matcher')->isFrontPage()) {
-      // Token processed before the header search.
-      if ($form['form_id']['#id'] === 'edit-views-exposed-form') {
-        return;
-      }
-    }
-    elseif (strpos(\Drupal::service('path.current')->getPath(), '/extracts') === 0) {
-      // Sidebar search is processed last (the three facets also get tagged).
-      if ($form['form_id']['#id'] === 'edit-views-exposed-form--5') {
-        $form['search']['#placeholder'] = t('Search');
-        return;
-      }
-    }
-
     // This is for a Views exposed form INLINE search block.
     // There are templates needed for this. Replace cd-search.html.twig
     // with cd-search--inline.html.twig in cd-site-header.html.twig.
@@ -47,7 +28,7 @@ function common_design_subtheme_form_alter(&$form, FormStateInterface $form_stat
     $form['#attributes']['data-cd-icon'][] = '';
     $form['#attributes']['data-cd-component'][] = 'cd-search--inline';
     $form['#attributes']['data-cd-logo'][] = 'search';
-    $form['search']['#attributes']['placeholder'][] = t('What are you looking for?');
+    $form['search']['#attributes']['placeholder'][] = t('Search for phrases or keywords');
     $form['search']['#attributes']['class'][] = 'cd-search--inline__input';
     $form['search']['#attributes']['type'][] = 'search';
     $form['search']['#attributes']['id'][] = 'cd-search--inline';
@@ -56,6 +37,7 @@ function common_design_subtheme_form_alter(&$form, FormStateInterface $form_stat
     $form['actions']['submit']['#attributes']['data-twig-suggestion'] = 'search_submit';
     $form['actions']['submit']['#attributes']['class'][] = 'cd-search--inline__submit';
     $form['actions']['submit']['#attributes']['value'][] = 'Search';
+    $form['#action'] = "/extracts";
   }
 }
 


### PR DESCRIPTION
This reverts the previous 'work-around' as it wasn't working. This is more stable, with a new view created for the inline search in the header, which redirects to the 'main' view.