### PR TITLE
[OPS-7850] include config split, inactive, so it can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Everything else should be similar to other DSS D8 sites.
 
 For local development, add this line to settings.local.php:
 `$config['config_split.config_split.config_dev']['status'] = TRUE;`
-After importing a fresh database, run `drush csim` to enable devel, database
-log and stage_file_proxy.
+After importing a fresh database, run `drush cim` to enable devel, database log
+stage_file_proxy and views_ui.
 
 ## Content Management
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal-composer/preserve-paths": "^0.1.6",
         "drupal/admin_denied": "^1.1",
+        "drupal/config_split": "^2.0.0-beta4",
         "drupal/core-composer-scaffold": "^9.2.1",
         "drupal/core-dev": "^9.2.1",
         "drupal/core-project-message": "^9.2.1",
@@ -60,7 +61,6 @@
     "require-dev": {
         "drupal/coder": "^8.3",
         "drupal/config_filter": "^2.2",
-        "drupal/config_split": "^2.0.0-beta4",
         "drupal/console": "^1.0.2",
         "drupal/devel": "^4.1",
         "drupal/stage_file_proxy": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcff41ad0fa225b7c9d004bae843ce2f",
+    "content-hash": "1c8918efb1af557532e2ac93927ec85b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2107,6 +2107,84 @@
                 "source": "https://www.drupal.org/project/coder"
             },
             "time": "2021-02-06T10:44:32+00:00"
+        },
+        {
+            "name": "drupal/config_split",
+            "version": "2.0.0-beta4",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_split.git",
+                "reference": "2.0.0-beta4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_split-2.0.0-beta4.zip",
+                "reference": "2.0.0-beta4",
+                "shasum": "815af0f3ac3b51368624d7ecb07424b0d9ad6c87"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "conflict": {
+                "drush/drush": "<10"
+            },
+            "require-dev": {
+                "drupal/config_filter": "^1||^2"
+            },
+            "suggest": {
+                "drupal/chosen": "Chosen uses the Chosen jQuery plugin to make the <select> elements more user-friendly.",
+                "drupal/select2_all": "Applies the Select2 library to all select fields on the site similar to the Chosen module."
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-beta4",
+                    "datestamp": "1631393371",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^10"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Fabian Bircher",
+                    "homepage": "https://www.drupal.org/u/bircher",
+                    "email": "opensource@fabianbircher.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Nuvole Web",
+                    "homepage": "http://nuvole.org",
+                    "email": "info@nuvole.org",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "pescetti",
+                    "homepage": "https://www.drupal.org/user/436244"
+                }
+            ],
+            "description": "Configuration filter for importing and exporting extra config",
+            "homepage": "https://www.drupal.org/project/config_split",
+            "keywords": [
+                "Drupal",
+                "configuration",
+                "configuration management"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/config_split",
+                "issues": "https://www.drupal.org/project/issues/config_split",
+                "slack": "https://drupal.slack.com/archives/C45342CDD"
+            }
         },
         {
             "name": "drupal/core",
@@ -12894,84 +12972,6 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/config_filter",
                 "issues": "https://www.drupal.org/project/issues/config_filter",
-                "slack": "https://drupal.slack.com/archives/C45342CDD"
-            }
-        },
-        {
-            "name": "drupal/config_split",
-            "version": "2.0.0-beta4",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/config_split.git",
-                "reference": "2.0.0-beta4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_split-2.0.0-beta4.zip",
-                "reference": "2.0.0-beta4",
-                "shasum": "815af0f3ac3b51368624d7ecb07424b0d9ad6c87"
-            },
-            "require": {
-                "drupal/core": "^8.8 || ^9"
-            },
-            "conflict": {
-                "drush/drush": "<10"
-            },
-            "require-dev": {
-                "drupal/config_filter": "^1||^2"
-            },
-            "suggest": {
-                "drupal/chosen": "Chosen uses the Chosen jQuery plugin to make the <select> elements more user-friendly.",
-                "drupal/select2_all": "Applies the Select2 library to all select fields on the site similar to the Chosen module."
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "2.0.0-beta4",
-                    "datestamp": "1631393371",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
-                    }
-                },
-                "drush": {
-                    "services": {
-                        "drush.services.yml": "^10"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Fabian Bircher",
-                    "homepage": "https://www.drupal.org/u/bircher",
-                    "email": "opensource@fabianbircher.com",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Nuvole Web",
-                    "homepage": "http://nuvole.org",
-                    "email": "info@nuvole.org",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "pescetti",
-                    "homepage": "https://www.drupal.org/user/436244"
-                }
-            ],
-            "description": "Configuration filter for importing and exporting extra config",
-            "homepage": "https://www.drupal.org/project/config_split",
-            "keywords": [
-                "Drupal",
-                "configuration",
-                "configuration management"
-            ],
-            "support": {
-                "source": "https://git.drupalcode.org/project/config_split",
-                "issues": "https://www.drupal.org/project/issues/config_split",
                 "slack": "https://drupal.slack.com/archives/C45342CDD"
             }
         },

--- a/config/config_split.config_split.config_dev.yml
+++ b/config/config_split.config_split.config_dev.yml
@@ -10,17 +10,10 @@ storage: folder
 folder: ../config_dev
 module:
   config_filter: 0
-  config_split: 0
   dblog: 0
   devel: 0
   stage_file_proxy: 0
   views_ui: 0
 theme: {  }
-complete_list:
-  - config_split.config_split.config_dev
-  - dblog.settings
-  - devel.settings
-  - devel.toolbar.settings
-  - stage_file_proxy.settings
-  - views.view.watchdog
+complete_list: {  }
 partial_list: {  }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -8,6 +8,7 @@ module:
   ckeditor: 0
   color: 0
   config: 0
+  config_split: 0
   contact: 0
   contextual: 0
   ctools: 0


### PR DESCRIPTION
Follow-on from https://github.com/UN-OCHA/pocam8-site/pull/97

As in UN-OCHA/common-design-site#119 (comment), I've included config_split module as enabled, but without the split activated.

I'd imagined the module only needs to be enabled on the local site, but that would require enabling all of the 'split' modules on each database refresh.