### PR TITLE
[OPS-7459] user expire 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "drupal/token_filter": "^1.2",
         "drupal/tome": "^1.5",
         "drupal/tome_static_azure": "1.0.x-dev",
+        "drupal/user_expire": "^1.0",
         "drupal/views_data_export": "^1.0",
         "drush/drush": "^10.3",
         "npm-asset/select2": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69658e6177f7115b760a4daa181c8710",
+    "content-hash": "6ec6ca49be239e09ab4f0732bc54790b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4354,6 +4354,61 @@
             "homepage": "https://www.drupal.org/project/tome",
             "support": {
                 "source": "https://git.drupalcode.org/project/tome"
+            }
+        },
+        {
+            "name": "drupal/user_expire",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/user_expire.git",
+                "reference": "8.x-1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/user_expire-8.x-1.0.zip",
+                "reference": "8.x-1.0",
+                "shasum": "70c5ebffe7f28f97c270de0c004dbfd4c174ffb8"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0",
+                    "datestamp": "1633965091",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Erik Webb (erikwebb)",
+                    "homepage": "https://www.drupal.org/u/erikwebb",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Greg Knaddison (greggles)",
+                    "homepage": "https://www.drupal.org/u/greggles",
+                    "role": "Co-maintainer"
+                },
+                {
+                    "name": "shelane",
+                    "homepage": "https://www.drupal.org/user/2674989"
+                }
+            ],
+            "description": "Allows an administrator to define a date on which to expire a user account.",
+            "homepage": "https://www.drupal.org/project/user_expire",
+            "support": {
+                "source": "https://git.drupal.org/project/user_expire.git",
+                "issues": "https://www.drupal.org/project/issues/user_expire"
             }
         },
         {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,5 +1,8 @@
 {
   "patches": {
+    "drupal/azure_storage": {
+      "https://www.drupal.org/project/azure_storage/issues/3261907": "https://git.drupalcode.org/project/azure_storage/-/merge_requests/1.diff"
+    },
     "drupal/facets": {
       "https://www.drupal.org/project/facets/issues/3005040": "https://www.drupal.org/files/issues/2021-05-13/facets-hierarchy-allow-different-types-3005040-13.patch",
       "https://www.drupal.org/project/facets/issues/2979223": "https://www.drupal.org/files/issues/2020-12-02/2979223--39.patch"
@@ -7,8 +10,9 @@
     "drupal/select2": {
       "https://www.drupal.org/project/select2/issues/3078085": "https://www.drupal.org/files/issues/2020-06-17/hierarchical-facet-widget-3078085-3.patch"
     },
-    "drupal/azure_storage": {
-      "https://www.drupal.org/project/azure_storage/issues/3261907": "https://git.drupalcode.org/project/azure_storage/-/merge_requests/1.diff"
+    "drupal/user_expire": {
+      "Allow the notification email to be customised": "https://git.drupalcode.org/project/user_expire/-/merge_requests/5.diff",
+      "Reset expiration when user is reactivated": "https://git.drupalcode.org/project/user_expire/-/merge_requests/6.diff"
     }
   }
 }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -61,6 +61,7 @@ module:
   toolbar: 0
   tour: 0
   user: 0
+  user_expire: 0
   menu_link_content: 1
   pathauto: 1
   views: 10

--- a/config/user_expire.settings.yml
+++ b/config/user_expire.settings.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: PeDvVH4C3IZ7QFkvC1BUv3BZJVc7jLwQmJAEttVuVOw
+frequency: 432000
+offset: 604800
+user_expire_roles:
+  authenticated: 15552000

--- a/symfony.lock
+++ b/symfony.lock
@@ -143,14 +143,26 @@
     "drupal/tome": {
         "version": "1.5.0"
     },
+    "drupal/tome_base": {
+        "version": "1.5.0"
+    },
+    "drupal/tome_static": {
+        "version": "1.5.0"
+    },
     "drupal/tome_static_azure": {
         "version": "1.0.x-dev"
+    },
+    "drupal/tome_sync": {
+        "version": "1.5.0"
     },
     "drupal/upgrade_rector": {
         "version": "1.0.0-alpha7"
     },
     "drupal/upgrade_status": {
         "version": "3.13.0"
+    },
+    "drupal/user_expire": {
+        "version": "1.0.0"
     },
     "drupal/views_data_export": {
         "version": "1.0.0"


### PR DESCRIPTION
https://humanitarian.atlassian.net/browse/OPS-7459

Adds and configures user_expire with the patches mentioned in https://github.com/UN-OCHA/assessmentregistry8-site/pull/360

Instead of https://github.com/UN-OCHA/pocam8-site/pull/131 - this directly to the main branch.